### PR TITLE
Bump pdfbox

### DIFF
--- a/target/classes/META-INF/maven/com.VolvoIT.test/UCHPRewrite/pom.xml
+++ b/target/classes/META-INF/maven/com.VolvoIT.test/UCHPRewrite/pom.xml
@@ -137,7 +137,7 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xs
   <dependency>
     <groupId>org.apache.pdfbox</groupId>
     <artifactId>pdfbox</artifactId>
-    <version>2.0.3</version>
+    <version>2.0.24</version>
   </dependency>
 </dependencies>
   <build>


### PR DESCRIPTION
Bumps pdfbox from 2.0.3 to 2.0.24.

---
updated-dependencies:
- dependency-name: org.apache.pdfbox:pdfbox dependency-type: direct:production ...