### PR TITLE
Bump pdfbox from 2.0.3 to 2.0.24

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -132,7 +132,7 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xs
   <dependency>
     <groupId>org.apache.pdfbox</groupId>
     <artifactId>pdfbox</artifactId>
-    <version>2.0.3</version>
+    <version>2.0.24</version>
   </dependency>
 </dependencies>
   <build>


### PR DESCRIPTION
Bumps pdfbox from 2.0.3 to 2.0.24.

---
updated-dependencies:
- dependency-name: org.apache.pdfbox:pdfbox dependency-type: direct:production ...